### PR TITLE
Adding prefix matching to other commands

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -47,12 +47,13 @@ Keywords:
     lts
         Represents the most recent LTS release of Node.js.`
 
-	INVALID_VERSION_FORMAT_ERROR string = "polyn: invalid version format"
-	UNSUPPORTED_ARCH_ERROR       string = "polyn: unsupported CPU architecture"
-	UNSUPPORTED_OS_ERROR         string = "polyn: unsupported operating system"
+	NO_DOWNLOADED_NODEJS_MESSAGE string = "There are no Node.js versions downloaded.\nTo download a Node.js version, use the 'add' or 'install' command."
+
+	UNSUPPORTED_ARCH_ERROR string = "polyn error: unsupported CPU architecture"
+	UNSUPPORTED_OS_ERROR   string = "polyn error: unsupported operating system"
 
 	// PolyNode's version.
-	VERSION string = "v2.0.10"
+	VERSION string = "v2.1.0"
 )
 
 // NA is for Not Applicable.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -21,7 +21,7 @@ func Handle(args []string, operatingSystem models.OperatingSystem, arch models.A
 	switch command {
 	case constants.ADD:
 		if len(args) > 1 {
-			err = add(convertKeywordToVersion(args[1], config), operatingSystem, arch, config)
+			err = add(convertKeywordToVersion(args[1], operatingSystem, arch, config), operatingSystem, arch, config)
 		} else {
 			fmt.Println(constants.HELP)
 		}
@@ -29,7 +29,7 @@ func Handle(args []string, operatingSystem models.OperatingSystem, arch models.A
 		current()
 	case constants.INSTALL:
 		if len(args) > 1 {
-			err = install(convertKeywordToVersion(args[1], config), operatingSystem, arch, config)
+			err = install(convertKeywordToVersion(args[1], operatingSystem, arch, config), operatingSystem, arch, config)
 		} else {
 			fmt.Println(constants.HELP)
 		}


### PR DESCRIPTION
PolyNode already uses prefix matching for the `search` command. This pull request adds prefix matching to the `add`, `install`, `use`, `rm/remove` and `temp` commands.