### PR TITLE
Fixing a bug in the IsValidVersionFormat() function that would allow …

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ eval $(polyn temp 23)
 
 #### Temporarily setting your Node.js on Windows
 
-Unfortunately, Windows doesn't have a command equivalent to the POSIX `eval`. You will have to run `polyn temp <version>` and then copy and paste the command it outputs.
+Unfortunately, Windows doesn't have a command equivalent to the POSIX `eval`. You will have to run `polyn temp <version or prefix>` and then copy and paste the command it outputs.
 
 ### Downloading and setting your default Node.js to a new version
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -53,7 +53,7 @@ Keywords:
 	UNSUPPORTED_OS_ERROR   string = "polyn error: unsupported operating system"
 
 	// PolyNode's version.
-	VERSION string = "v2.1.0"
+	VERSION string = "v2.1.1"
 )
 
 // NA is for Not Applicable.

--- a/internal/node/commands.go
+++ b/internal/node/commands.go
@@ -259,7 +259,7 @@ func temp(version string, operatingSystem models.OperatingSystem) error {
 	}
 
 	if operatingSystem == constants.WINDOWS {
-		fmt.Println("\nIf using Command Prompt, run this command:")
+		fmt.Println("If using Command Prompt, run this command:")
 		fmt.Println("\n  set PATH=" + internal.PolynHomeDir + "\\node\\" + version + ";%PATH%")
 		fmt.Println("\nIf using PowerShell, run this command:")
 		fmt.Println("\n  $env:Path = \"" + internal.PolynHomeDir + "\\node\\" + version + ";\" + $env:Path")

--- a/internal/utilities/utils.go
+++ b/internal/utilities/utils.go
@@ -90,6 +90,9 @@ func IsValidVersionFormat(version string) bool {
 		'9': {},
 	}
 	for _, part := range parts {
+		if part == "" {
+			return false
+		}
 		for _, char := range part {
 			if _, exists := validChars[char]; !exists {
 				return false


### PR DESCRIPTION
…versions in the form of "Major.minor." to pass. This is no longer the case